### PR TITLE
fixed gradle building for linux and freebsd

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,9 @@ task runZTLDR(type: JavaExec) {
         environment "LD_LIBRARY_PATH", jniDir
         environment "DYLD_FALLBACK_LIBRARY_PATH", jniDir
         environment "DYLD_LIBRARY_PATH", jniDir
-        jvmArgs "-XstartOnFirstThread"
+        if (DefaultNativePlatform.currentOperatingSystem.isMacOsX()) {
+            jvmArgs "-XstartOnFirstThread"
+        }
     }
     environment "HALSIM_EXTENSIONS", hal
     environment "ROBOT_NAME", "ztldr"


### PR DESCRIPTION
The gradle file falsely assumes that if you are not on windows, you are on MacOS. It passes a flag only compatible with OSx, breaking the JVM for Linux and FreeBSD