### PR TITLE
fixed the feeder with: Consistent naming conventions Correct motor requests (why is it called indexReq right now) Remove curPosition Add all variables with placeholder values for all velocities in both Feeder and the yml constants Add clamping methods for all motor requests for redundancy, don't directly set motor requests w/o clamping (look at Shooter for example) Add control requests to applyState() Remove CommandScheduler.getInstance().getDefaultButtonLoop().poll(); in line 26 (or explain its purpose w/ a comment)

### DIFF
--- a/src/main/java/com/team1816/season/RobotContainer.java
+++ b/src/main/java/com/team1816/season/RobotContainer.java
@@ -74,7 +74,7 @@ public class RobotContainer extends BaseRobotContainer {
         // controller.leftBumper().whileTrue(superstructure.setStateCommand(Superstructure.WantedSuperState.INTAKE_OUT));
         // controller.rightBumper().whileTrue(superstructure.setStateCommand(Superstructure.WantedSuperState.INTAKE_IN));
     }
-    
+
     public final void registerCommands() {
         /**
          * Individual Subsystem Action (not needed, just here)
@@ -88,11 +88,11 @@ public class RobotContainer extends BaseRobotContainer {
         }));
 
         NamedCommands.registerCommand("passiveFeeding", Commands.runOnce(() -> {
-             getSuperstructure().setWantedFeederState(Superstructure.WantedFeederState.PASSIVE_FEEDING);
+             getSuperstructure().setWantedFeederState(Superstructure.WantedFeederState.SLOW_FEEDING);
         }));
 
         NamedCommands.registerCommand("activeFeeding", Commands.runOnce(() -> {
-             getSuperstructure().setWantedFeederState(Superstructure.WantedFeederState.ACTIVE_FEEDING);
+             getSuperstructure().setWantedFeederState(Superstructure.WantedFeederState.FAST_FEEDING);
         }));
 
         NamedCommands.registerCommand("openGatekeeper", Commands.runOnce(() -> {

--- a/src/main/java/com/team1816/season/subsystems/Feeder.java
+++ b/src/main/java/com/team1816/season/subsystems/Feeder.java
@@ -1,8 +1,10 @@
 package com.team1816.season.subsystems;
 
 import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.team1816.lib.Singleton;
 import com.team1816.lib.hardware.components.motor.IMotor;
 import com.team1816.lib.subsystems.ITestableSubsystem;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -12,38 +14,41 @@ import static com.team1816.lib.Singleton.factory;
 public class Feeder extends SubsystemBase implements ITestableSubsystem {
 
     public static final String NAME = "feeder";
-    private final IMotor feederMotor = (IMotor)factory.getDevice(NAME, "feederMotor");
-//    private final IMotor feederMotorTop = (IMotor)factory.getDevice(NAME, "feederMotorTop"); //May need to implement
-    private double curPosition;
+    private final IMotor feedMotor = (IMotor)factory.getDevice(NAME, "feedMotor");
+    private double currentVelocity;
     private FEEDER_STATE wantedState = FEEDER_STATE.IDLING;
-    VelocityVoltage indexReq = new VelocityVoltage(0);
+    private VelocityVoltage velocityReq = new VelocityVoltage(0);
+
+    //VELOCITY AND POSITION VALUES
+    public final double FEED_VELOCITY_FAST_FEEDING = Singleton.factory.getConstant(NAME, "fastFeeding", 0);
+    public final double FEED_VELOCITY_SLOW_FEEDING = Singleton.factory.getConstant(NAME, "slowFeeding", 0);
+    public final double FEED_VELOCITY_REVERSING = Singleton.factory.getConstant(NAME, "reversing", 0);
+    public final double FEED_VELOCITY_IDLING = Singleton.factory.getConstant(NAME, "idling", 0);
 
     @Override
     public void periodic() {
         readFromHardware();
         applyState();
-
-        CommandScheduler.getInstance().getDefaultButtonLoop().poll();
     }
 
     @Override
     public void readFromHardware() {
-        curPosition = feederMotor.getMotorPosition();
+        currentVelocity = feedMotor.getMotorVelocity();
     }
 
     private void applyState() {
         switch (wantedState) {
-            case PASSIVE_FEEDING:
-
+            case SLOW_FEEDING:
+                setFeedVelocity(FEED_VELOCITY_SLOW_FEEDING);
                 break;
-            case ACTIVE_FEEDING:
-
+            case FAST_FEEDING:
+                setFeedVelocity(FEED_VELOCITY_FAST_FEEDING);
                 break;
-            case AGITATING:
-
+            case REVERSING:
+                setFeedVelocity(FEED_VELOCITY_REVERSING);
                 break;
             case IDLING:
-
+                setFeedVelocity(FEED_VELOCITY_IDLING);
                 break;
             default:
                 break;
@@ -52,12 +57,16 @@ public class Feeder extends SubsystemBase implements ITestableSubsystem {
         SmartDashboard.putString("Feeder state: ", wantedState.toString());
     }
 
+    private void setFeedVelocity(double feedVelocity){
+        double clampedVelocity = MathUtil.clamp(feedVelocity, -80, 80);
 
+        feedMotor.setControl(velocityReq.withVelocity(clampedVelocity));
+    }
 
     public enum FEEDER_STATE {
-        PASSIVE_FEEDING,
-        ACTIVE_FEEDING,
-        AGITATING,
+        SLOW_FEEDING,
+        FAST_FEEDING,
+        REVERSING,
         IDLING
     }
 

--- a/src/main/java/com/team1816/season/subsystems/Superstructure.java
+++ b/src/main/java/com/team1816/season/subsystems/Superstructure.java
@@ -95,9 +95,9 @@ public class Superstructure extends SubsystemBase {
     }
 
     public enum WantedFeederState {
-        PASSIVE_FEEDING,
-        ACTIVE_FEEDING,
-        AGITATING,
+        SLOW_FEEDING,
+        FAST_FEEDING,
+        REVERSING,
         IDLING
     }
 
@@ -373,8 +373,8 @@ public class Superstructure extends SubsystemBase {
 
     private void agitate() {
         switch(wantedFeederState) {
-            case AGITATING, PASSIVE_FEEDING, ACTIVE_FEEDING, IDLING:
-                feeder.setWantedState(Feeder.FEEDER_STATE.AGITATING);
+            case REVERSING, SLOW_FEEDING, FAST_FEEDING, IDLING:
+                feeder.setWantedState(Feeder.FEEDER_STATE.REVERSING);
                 break;
         }
     }
@@ -407,9 +407,9 @@ public class Superstructure extends SubsystemBase {
         }
 
         switch (wantedFeederState) {
-            case PASSIVE_FEEDING -> feeder.setWantedState(Feeder.FEEDER_STATE.PASSIVE_FEEDING);
-            case ACTIVE_FEEDING -> feeder.setWantedState(Feeder.FEEDER_STATE.ACTIVE_FEEDING);
-            case AGITATING -> feeder.setWantedState(Feeder.FEEDER_STATE.AGITATING);
+            case SLOW_FEEDING -> feeder.setWantedState(Feeder.FEEDER_STATE.SLOW_FEEDING);
+            case FAST_FEEDING -> feeder.setWantedState(Feeder.FEEDER_STATE.FAST_FEEDING);
+            case REVERSING -> feeder.setWantedState(Feeder.FEEDER_STATE.REVERSING);
             case IDLING -> feeder.setWantedState(Feeder.FEEDER_STATE.IDLING);
         }
 
@@ -417,11 +417,11 @@ public class Superstructure extends SubsystemBase {
          * What is this doing???
          */
         if (feederControlState == FeederControlState.OVERRIDING) {
-            feeder.setWantedState(Feeder.FEEDER_STATE.ACTIVE_FEEDING);
+            feeder.setWantedState(Feeder.FEEDER_STATE.FAST_FEEDING);
         }
         else {
             if (wantedIntakeState == WantedIntakeState.INTAKING || wantedGatekeeperState == WantedGatekeeperState.OPEN) {
-                feeder.setWantedState(Feeder.FEEDER_STATE.PASSIVE_FEEDING);
+                feeder.setWantedState(Feeder.FEEDER_STATE.SLOW_FEEDING);
             }
             else {
                 feeder.setWantedState(Feeder.FEEDER_STATE.IDLING);

--- a/src/main/resources/yaml/ztldr.yml
+++ b/src/main/resources/yaml/ztldr.yml
@@ -85,7 +85,7 @@ subsystems:
 
     feeder:
         devices:
-            feederMotor:
+            feedMotor:
                 deviceType: TalonFX
                 id: 16
                 motorRotation: Clockwise_Positive
@@ -93,6 +93,11 @@ subsystems:
                 motionMagic:
                     expoKV: 0.05
                     expoKA: 0.04
+        constants:
+            fastFeeding: 50
+            slowFeeding: 20
+            reversing: -50
+            idling: 0
     shooter:
         devices:
             topLaunchMotor:


### PR DESCRIPTION
Did:
Consistent naming conventions
Correct motor requests (why is it called indexReq right now)
Remove curPosition
Add all variables with placeholder values for all velocities in both Feeder and the yml constants
Add clamping methods for all motor requests for redundancy, don't directly set motor requests w/o clamping (look at Shooter for example)
Add control requests to applyState()
Remove CommandScheduler.getInstance().getDefaultButtonLoop().poll(); in line 26 (or explain its purpose w/ a comment)