### PR TITLE
fixed the climber with: Consistent naming conventions (particularly looking at the motor names, not climberFlipMotor, just flipMotor) Correct motor requests Take calls to RobotFactory out of the enum for CLIMBER_STATE Add all variables with placeholder values for positions and velocities in both Climber and the yml constants Add clamping methods for all motor requests for redundancy, don't directly set motor requests w/o clamping (look at Shooter for example) Add control requests to applyState()

### DIFF
--- a/src/main/java/com/team1816/season/subsystems/Climber.java
+++ b/src/main/java/com/team1816/season/subsystems/Climber.java
@@ -1,12 +1,16 @@
 package com.team1816.season.subsystems;
 
+import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.team1816.lib.hardware.components.motor.IMotor;
 import com.team1816.lib.subsystems.ITestableSubsystem;
+import com.team1816.lib.util.GreenLogger;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismRoot2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -15,17 +19,35 @@ import static com.team1816.lib.Singleton.factory;
 public class Climber extends SubsystemBase implements ITestableSubsystem {
 
     public static final String NAME = "climber";
-    private final IMotor climberFlipMotor = (IMotor)factory.getDevice(NAME, "climberFlipMotor");
-    private final IMotor linearMotor = (IMotor)factory.getDevice(NAME, "linearMotor"); //Build-team had a cool name for this
-    private double curPosition;
+    private final IMotor flipMotor = (IMotor)factory.getDevice(NAME, "flipMotor");
+    private final IMotor linearSlideMotor = (IMotor)factory.getDevice(NAME, "linearSlideMotor");
+    private double linearSlidePosition;
     private CLIMBER_STATE wantedState = CLIMBER_STATE.IDLING;
-    VelocityVoltage climReq = new VelocityVoltage(0);
+    private PositionVoltage positionReq = new PositionVoltage(0);
 
-    //MECHANISMS *Need to ask build team for details
+    //YAML VALUES
+    private double flipIdling = factory.getConstant(NAME, "flipIdling", 0);
+    private double flipL3UpClimbing = factory.getConstant(NAME, "flipL3UpClimbing", 0);
+    private double flipL3DownClimbing = factory.getConstant(NAME, "flipL3DownClimbing", 0);
+    private double flipL1UpClimbing = factory.getConstant(NAME, "flipL1UpClimbing", 0);
+    private double flipL1DownClimbing = factory.getConstant(NAME, "flipL1DownClimbing", 0);
+
+    private double linearSlideIdling = factory.getConstant(NAME, "linearSlideIdling", 0);
+    private double linearSlideL3UpClimbing = factory.getConstant(NAME, "linearSlideL3UpClimbing", 0);
+    private double linearSlideL3DownClimbing = factory.getConstant(NAME, "linearSlideL3DownClimbing", 0);
+    private double linearSlideL1UpClimbing = factory.getConstant(NAME, "linearSlideL1UpClimbing", 0);
+    private double linearSlideL1DownClimbing = factory.getConstant(NAME, "linearSlideL1DownClimbing", 0);
+
+    //PHYSICAL SUBSYSTEM DEPENDENT CONSTANTS
+    private static final double MAX_FLIP_MOTOR_CLAMP = 100;
+    private static final double MIN_FLIP_MOTOR_CLAMP = 0;
+    private static final double MAX_LINEAR_SLIDE_MOTOR_CLAMP = 100;
+    private static final double MIN_LINEAR_SLIDE_MOTOR_CLAMP = 0;
+
     public Mechanism2d climberMech = new Mechanism2d(3, 3, new Color8Bit(50, 15, 50));
-    public MechanismRoot2d climberMechRoot = climberMech.getRoot("Climber Root", 1.5,0);
-    public MechanismLigament2d climberLiftML = climberMechRoot.append(
-        new MechanismLigament2d("Climber Lift", 1, 90));
+    public MechanismRoot2d climberMechRoot = climberMech.getRoot("Climber Root", 1,0);
+    public MechanismLigament2d climberArm = climberMechRoot.append(new MechanismLigament2d("Climber Lift", 1, 70));
+    public MechanismLigament2d linearSlide = climberMechRoot.append(new MechanismLigament2d("Linear Slide", 0, 0, 10, new Color8Bit(Color.kPurple)));
 
     public Climber () {
         super();
@@ -40,62 +62,59 @@ public class Climber extends SubsystemBase implements ITestableSubsystem {
 
     @Override
     public void readFromHardware() {
-        curPosition = climberFlipMotor.getMotorPosition();
-        climberLiftML.setLength(wantedState.getLength());
+        linearSlidePosition = linearSlideMotor.getMotorPosition();
+        linearSlide.setLength(linearSlidePosition/(MAX_LINEAR_SLIDE_MOTOR_CLAMP-MIN_LINEAR_SLIDE_MOTOR_CLAMP));
     }
 
     private void applyState() {
         switch (wantedState) {
             case IDLING:
-
+                setFlipMotor(flipIdling);
+                setLinearSlideMotor(linearSlideIdling);
                 break;
-            case L3_CLIMBING:
-
+            case L3_UP_CLIMBING:
+                setFlipMotor(flipL3UpClimbing);
+                setLinearSlideMotor(linearSlideL3UpClimbing);
                 break;
             case L3_DOWN_CLIMBING:
-
+                setFlipMotor(flipL3DownClimbing);
+                setLinearSlideMotor(linearSlideL3DownClimbing);
                 break;
-            case L1_CLIMBING:
-
+            case L1_UP_CLIMBING:
+                setFlipMotor(flipL1UpClimbing);
+                setLinearSlideMotor(linearSlideL1UpClimbing);
                 break;
             case L1_DOWN_CLIMBING:
-
+                setFlipMotor(flipL1DownClimbing);
+                setLinearSlideMotor(linearSlideL1DownClimbing);
                 break;
             default:
+                GreenLogger.log("Climber state: "+wantedState+" is not accounted for in applyState()");
                 break;
         }
 
         SmartDashboard.putString("Climber state: ", wantedState.toString());
     }
 
-    public enum CLIMBER_STATE {
-        IDLING(
-            factory.getConstant(NAME, "idlePosition", 0, true)
-        ),
-        L3_CLIMBING(
-            factory.getConstant(NAME, "L3ClimbingPosition", 10, true)
-        ),
-        L3_DOWN_CLIMBING(
-            factory.getConstant(NAME, "L3ClimbingDownPosition", 0, true)
-        ),
-        L1_CLIMBING(
-            factory.getConstant(NAME, "L1ClimbingPosition", 10, true)
-        ),
-        L1_DOWN_CLIMBING(
-            factory.getConstant(NAME, "L1ClimbingDownPosition", 0, true)
-        );
+    private void setFlipMotor(double position){
+        double clampedPosition = MathUtil.clamp(position, MIN_FLIP_MOTOR_CLAMP, MAX_FLIP_MOTOR_CLAMP);
 
-
-        private final double length;
-        CLIMBER_STATE (double length) {
-            this.length = length;
-        }
-
-        public double getLength() {
-            return length;
-        }
+        flipMotor.setControl(positionReq.withPosition(clampedPosition));
     }
 
+    private void setLinearSlideMotor(double position){
+        double clampedPosition = MathUtil.clamp(position, MIN_LINEAR_SLIDE_MOTOR_CLAMP, MAX_LINEAR_SLIDE_MOTOR_CLAMP);
+
+        linearSlideMotor.setControl(positionReq.withPosition(clampedPosition));
+    }
+
+    public enum CLIMBER_STATE {
+        IDLING,
+        L3_UP_CLIMBING,
+        L3_DOWN_CLIMBING,
+        L1_UP_CLIMBING,
+        L1_DOWN_CLIMBING
+    }
 
     public void setWantedState(CLIMBER_STATE wantedState) {
         this.wantedState = wantedState;

--- a/src/main/java/com/team1816/season/subsystems/Superstructure.java
+++ b/src/main/java/com/team1816/season/subsystems/Superstructure.java
@@ -231,7 +231,7 @@ public class Superstructure extends SubsystemBase {
     private void l1Climbing() {
         switch (climbState) { //WILL PROBABLY WORK DIFFERENTLY, JUST A BASIS FOR NOW
             case L1_CLIMING:
-                climber.setWantedState(Climber.CLIMBER_STATE.L1_CLIMBING);
+                climber.setWantedState(Climber.CLIMBER_STATE.L1_UP_CLIMBING);
                 intake.setWantedState(Intake.INTAKE_STATE.IDLING);
                 shooter.setWantedState(Shooter.SHOOTER_STATE.IDLE);
                 feeder.setWantedState(Feeder.FEEDER_STATE.IDLING);
@@ -246,7 +246,7 @@ public class Superstructure extends SubsystemBase {
     private void l3Climbing() {
         switch (climbState) { //WILL PROBABLY WORK DIFFERENTLY, JUST A BASIS FOR NOW
             case L3_CLIMBING:
-                climber.setWantedState(Climber.CLIMBER_STATE.L3_CLIMBING);
+                climber.setWantedState(Climber.CLIMBER_STATE.L3_UP_CLIMBING);
                 intake.setWantedState(Intake.INTAKE_STATE.IDLING);
                 shooter.setWantedState(Shooter.SHOOTER_STATE.IDLE);
                 feeder.setWantedState(Feeder.FEEDER_STATE.IDLING);

--- a/src/main/resources/yaml/ztldr.yml
+++ b/src/main/resources/yaml/ztldr.yml
@@ -66,7 +66,7 @@ subsystems:
             upAngle: 45
     climber:
         devices:
-            climberFlipMotor:
+            flipMotor:
                 deviceType: TalonFX
                 id: 16
                 motorRotation: Clockwise_Positive
@@ -74,7 +74,7 @@ subsystems:
                 motionMagic:
                     expoKV: 0.05
                     expoKA: 0.04
-            linearMotor:
+            linearSlideMotor:
                 deviceType: TalonFX
                 id: 28
                 motorRotation: Clockwise_Positive
@@ -82,6 +82,18 @@ subsystems:
                 motionMagic:
                     expoKV: 0.05
                     expoKA: 0.04
+        constants:
+            flipIdling: 0
+            flipL3UpClimbing: 0
+            flipL3DownClimbing: 0
+            flipL1UpClimbing: 0
+            flipL1DownClimbing: 0
+
+            linearSlideIdling: 0
+            linearSlideL3UpClimbing: 0
+            linearSlideL3DownClimbing: 0
+            linearSlideL1UpClimbing: 0
+            linearSlideL1DownClimbing: 0
 
     feeder:
         devices:


### PR DESCRIPTION
Consistent naming conventions (particularly looking at the motor names, not climberFlipMotor, just flipMotor)
Correct motor requests
Take calls to RobotFactory out of the enum for CLIMBER_STATE
Add all variables with placeholder values for positions and velocities in both Climber and the yml constants
Add clamping methods for all motor requests for redundancy, don't directly set motor requests w/o clamping (look at Shooter for example)
Add control requests to applyState()