### PR TITLE
fixed the gatekeeper with: Consistent naming conventions Correct motor requests (why is it called indexReq right now) (also why is there a VoltageOut req) Make sure all instance variables are private Remove curTopPosition and curBottomPosition Add all variables with placeholder values for all velocities in both Gatekeeper and the yml constants Add control requests to applyState() (using said variables) Add clamps to the setVelocity methods Remove CommandScheduler.getInstance().getDefaultButtonLoop().poll(); in line 26 (or explain its purpose w/ a comment

### DIFF
--- a/src/main/java/com/team1816/season/subsystems/Gatekeeper.java
+++ b/src/main/java/com/team1816/season/subsystems/Gatekeeper.java
@@ -1,11 +1,10 @@
 package com.team1816.season.subsystems;
 
 import com.ctre.phoenix6.controls.VelocityVoltage;
-import com.ctre.phoenix6.controls.VoltageOut;
 import com.team1816.lib.hardware.components.motor.IMotor;
 import com.team1816.lib.subsystems.ITestableSubsystem;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import static com.team1816.lib.Singleton.factory;
@@ -13,39 +12,45 @@ import static com.team1816.lib.Singleton.factory;
 public class Gatekeeper extends SubsystemBase implements ITestableSubsystem {
 
     public static final String NAME = "gatekeeper";
-    private final IMotor gatekeeperTopMotor = (IMotor)factory.getDevice(NAME, "gatekeeperTopMotor");
-    private final IMotor gatekeeperBottomMotor = (IMotor)factory.getDevice(NAME, "gatekeeperBottomMotor");
-    private double curTopPosition;
-    private double curBottomPosition;
+    private final IMotor topMotor = (IMotor)factory.getDevice(NAME, "topMotor");
+    private final IMotor bottomMotor = (IMotor)factory.getDevice(NAME, "bottomMotor");
     private GATEKEEPER_STATE wantedState = GATEKEEPER_STATE.CLOSED;
-    VelocityVoltage indexReq = new VelocityVoltage(0);
-    private VoltageOut voltageControl = new VoltageOut(0);
+    private VelocityVoltage voltageReq = new VelocityVoltage(0);
+
+    //YAML VALUES
+    private double topClosedVelocity = factory.getConstant(NAME, "topClosedVelocity", 0);
+    private double topOpenVelocity = factory.getConstant(NAME, "topOpenVelocity", 0);
+    private double bottomClosedVelocity = factory.getConstant(NAME, "bottomClosedVelocity", 0);
+    private double bottomOpenVelocity = factory.getConstant(NAME, "bottomOpenVelocity", 0);
+
+    //PHYSICAL SUBSYSTEM DEPENDENT CONSTANTS
+    private static final double MIN_TOP_MOTOR_CLAMP = 0;
+    private static final double MAX_TOP_MOTOR_CLAMP = 80;
+    private static final double MIN_BOTTOM_MOTOR_CLAMP = 0;
+    private static final double MAX_BOTTOM_MOTOR_CLAMP = 80;
 
     @Override
     public void periodic() {
         readFromHardware();
         applyState();
-
-        CommandScheduler.getInstance().getDefaultButtonLoop().poll();
     }
 
     @Override
     public void readFromHardware() {
-        curTopPosition = gatekeeperTopMotor.getMotorPosition();
-        curBottomPosition = gatekeeperBottomMotor.getMotorPosition();
     }
 
     private void applyState() {
         switch (wantedState) {
             case OPEN:
                 // TODO: Add correct velocity
-                setGatekeeperTopVelocity(10);
-                setGatekeeperBottomVelocity(5);
+                setTopVelocity(topOpenVelocity);
+                setBottomVelocity(bottomOpenVelocity);
                 break;
             case CLOSED:
+                setTopVelocity(topClosedVelocity);
+                setBottomVelocity(bottomClosedVelocity);
+                break;
             default:
-                setGatekeeperTopVelocity(0);
-                setGatekeeperBottomVelocity(0);
                 break;
         }
 
@@ -57,12 +62,16 @@ public class Gatekeeper extends SubsystemBase implements ITestableSubsystem {
         CLOSED
     }
 
-    private void setGatekeeperTopVelocity(double wantedVelocity) {
-        gatekeeperTopMotor.setControl(voltageControl.withOutput(wantedVelocity));
+    private void setTopVelocity(double velocity) {
+        double clampedVelocity = MathUtil.clamp(velocity, MIN_TOP_MOTOR_CLAMP, MAX_TOP_MOTOR_CLAMP);
+
+        topMotor.setControl(voltageReq.withVelocity(clampedVelocity));
     }
 
-    private void setGatekeeperBottomVelocity(double wantedVelocity) {
-        gatekeeperBottomMotor.setControl(voltageControl.withOutput(wantedVelocity));
+    private void setBottomVelocity(double velocity) {
+        double clampedVelocity = MathUtil.clamp(velocity, MIN_BOTTOM_MOTOR_CLAMP, MAX_BOTTOM_MOTOR_CLAMP);
+
+        bottomMotor.setControl(voltageReq.withVelocity(clampedVelocity));
     }
 
     public void setWantedState(GATEKEEPER_STATE state) {

--- a/src/main/resources/yaml/ztldr.yml
+++ b/src/main/resources/yaml/ztldr.yml
@@ -183,7 +183,7 @@ subsystems:
             distanceThreeLaunchVelocity: 30
     gatekeeper:
         devices:
-            gatekeeperTopMotor:
+            topMotor:
                 deviceType: TalonFX
                 id: 14
                 motorRotation: Clockwise_Positive
@@ -195,7 +195,7 @@ subsystems:
                     slot0:
                         kP: 0.1
                         kV: 0.1
-            gatekeeperBottomMotor:
+            bottomMotor:
                 deviceType: TalonFX
                 id: 22
                 motorRotation: Clockwise_Positive
@@ -203,6 +203,11 @@ subsystems:
                 motionMagic:
                     expoKV: 0.05
                     expoKA: 0.04
+        constants:
+            topClosedVelocity: 0
+            topOpenVelocity: 10
+            bottomClosedVelocity: 0
+            bottomOpenVelocity: 5
     ledManager:
         implemented: false
         devices:


### PR DESCRIPTION
fixed the gatekeeper, story is "Fix the Gatekeeper"